### PR TITLE
TMCloudDust.js セーブしたデータをロードするとエラーになる不具合を修正

### DIFF
--- a/MNKR_TMCloudDustMZ.js
+++ b/MNKR_TMCloudDustMZ.js
@@ -411,6 +411,8 @@ var TMPlugin = TMPlugin || {};
     }
   };
 
+  globalThis.Game_CloudDust = Game_CloudDust;
+
   //-----------------------------------------------------------------------------
   // Game_CharacterBase
   //


### PR DESCRIPTION
Game_CloudDust クラスがグローバルに公開されていないため、プラグインを導入してセーブしたデータをロードするとエラーが表示されていました。
それを修正します。

つちけむりデータ自体をセーブデータに含める必要すらなさそうですが、修正の規模が少し大きくなるので、今回は対応していません。